### PR TITLE
Add Bluesky reply follow filter

### DIFF
--- a/apple/shared/CoreEvents.swift
+++ b/apple/shared/CoreEvents.swift
@@ -347,6 +347,7 @@ struct ClientFilter: Decodable {
     var original = true
     var replies = true
     var repliesToMe = true
+    var repliesToUnfollowed = true
     var threads = true
     var boosts = true
     var quotes = true
@@ -359,6 +360,7 @@ struct ClientFilter: Decodable {
     enum CodingKeys: String, CodingKey {
         case original, replies, threads, boosts, quotes, media, text
         case repliesToMe = "replies_to_me"
+        case repliesToUnfollowed = "replies_to_unfollowed"
         case noMedia = "no_media"
         case myPosts = "my_posts"
         case myReplies = "my_replies"

--- a/core/include/fastsm/models/status.hpp
+++ b/core/include/fastsm/models/status.hpp
@@ -36,6 +36,13 @@ struct Status {
     // The replied-to author's handle, when known (Bluesky feeds carry the parent
     // post's author) — spoken by the "Replying to" speech field.
     std::optional<std::string> reply_to_handle;
+    // The replied-to author's DID, when a Bluesky feed embeds the parent post.
+    // Kept separate from in_reply_to_account_id so existing reply categories do
+    // not change merely because Bluesky supplied extra feed-view metadata.
+    std::optional<std::string> reply_to_author_id;
+    // Whether the authenticated Bluesky user follows the replied-to author.
+    // nullopt means the feed did not provide enough viewer data to know.
+    std::optional<bool> reply_to_author_followed;
     std::shared_ptr<Status> reblog; // the boosted status, when this is a boost
     std::shared_ptr<Status> quote;  // the quoted status
     std::vector<MediaAttachment> media_attachments;

--- a/core/include/fastsm/timeline/client_filter.hpp
+++ b/core/include/fastsm/timeline/client_filter.hpp
@@ -16,6 +16,7 @@ struct ClientFilter {
     bool original = true;      // original posts (not replies, not boosts)
     bool replies = true;       // replies to other people
     bool replies_to_me = true; // replies to the current user
+    bool replies_to_unfollowed = true; // Bluesky replies to people not followed
     bool threads = true;       // self-replies (thread continuations)
     bool boosts = true;        // boosts / reposts
     bool quotes = true;        // quote posts
@@ -27,8 +28,8 @@ struct ClientFilter {
 
     // Whether the filter would hide anything (else it can be dropped entirely).
     bool is_active() const {
-        return !(original && replies && replies_to_me && threads && boosts && quotes && media &&
-                 no_media && my_posts && my_replies && text.empty());
+        return !(original && replies && replies_to_me && replies_to_unfollowed && threads &&
+                 boosts && quotes && media && no_media && my_posts && my_replies && text.empty());
     }
 };
 

--- a/core/src/platform/bluesky/bluesky_map.cpp
+++ b/core/src/platform/bluesky/bluesky_map.cpp
@@ -274,14 +274,19 @@ Status map_feed_item(const json& item) {
     const json* post = obj(item, "post");
     Status inner = post ? map_post(*post) : Status{};
 
-    // The feed carries the reply parent as a full post view (with its author),
-    // so a reply row can name who it's replying to. The bare record only has
-    // the parent URI, so this is the one place the handle is available.
+    // The feed carries the reply parent as a full post view (with its author and
+    // viewer relationship), so capture everything needed by reply presentation
+    // and client filtering here without making another request.
     if (const json* reply = obj(item, "reply"))
         if (const json* parent = obj(*reply, "parent"))
-            if (const json* author = obj(*parent, "author"))
+            if (const json* author = obj(*parent, "author")) {
+                if (std::string did = str(*author, "did"); !did.empty())
+                    inner.reply_to_author_id = did;
                 if (std::string h = str(*author, "handle"); !h.empty())
                     inner.reply_to_handle = h;
+                if (const json* viewer = obj(*author, "viewer"))
+                    inner.reply_to_author_followed = !str(*viewer, "following").empty();
+            }
 
     // A repost "reason" turns the row into a boost authored by the reposter.
     if (const json* reason = obj(item, "reason")) {

--- a/core/src/session/core_session.cpp
+++ b/core/src/session/core_session.cpp
@@ -38,6 +38,7 @@ constexpr const char* kUpdateRepo = "masonasons/FastSMRW";
 json client_filter_to_json(const ClientFilter& f) {
     return {{"original", f.original},         {"replies", f.replies},
             {"replies_to_me", f.replies_to_me}, {"threads", f.threads},
+            {"replies_to_unfollowed", f.replies_to_unfollowed},
             {"boosts", f.boosts},             {"quotes", f.quotes},
             {"media", f.media},               {"no_media", f.no_media},
             {"my_posts", f.my_posts},         {"my_replies", f.my_replies},
@@ -49,6 +50,7 @@ ClientFilter client_filter_from_json(const json& j) {
     f.original = j.value("original", true);
     f.replies = j.value("replies", true);
     f.replies_to_me = j.value("replies_to_me", true);
+    f.replies_to_unfollowed = j.value("replies_to_unfollowed", true);
     f.threads = j.value("threads", true);
     f.boosts = j.value("boosts", true);
     f.quotes = j.value("quotes", true);

--- a/core/src/store/timeline_codec.cpp
+++ b/core/src/store/timeline_codec.cpp
@@ -9,8 +9,8 @@ namespace {
 // Bump this whenever the on-disk layout changes so older caches are rejected
 // cleanly (a magic mismatch -> empty) instead of being read with a mismatched
 // reader. v2 added Status::url. v6 added Notification group_key + notifications_count.
-// v7 added Status::filtered + tags.
-constexpr char kMagic[4] = {'F', 'S', 'C', '8'};
+// v7 added Status::filtered + tags. v9 added Bluesky reply-parent metadata.
+constexpr char kMagic[4] = {'F', 'S', 'C', '9'};
 // Guard against runaway recursion if a file is ever corrupt/misaligned: boost/
 // quote nesting is shallow in practice.
 constexpr int kMaxStatusDepth = 24;
@@ -221,6 +221,11 @@ void write_status(Writer& w, const Status& s) {
     w.i32(s.replies_count);
     w.opt_str(s.in_reply_to_id);
     w.opt_str(s.in_reply_to_account_id);
+    w.opt_str(s.reply_to_handle);
+    w.opt_str(s.reply_to_author_id);
+    w.boolean(s.reply_to_author_followed.has_value());
+    if (s.reply_to_author_followed)
+        w.boolean(*s.reply_to_author_followed);
     // reblog / quote (recursive)
     w.boolean(static_cast<bool>(s.reblog));
     if (s.reblog)
@@ -301,6 +306,10 @@ Status read_status(Reader& r, int depth = 0) {
     s.replies_count = r.i32();
     s.in_reply_to_id = r.opt_str();
     s.in_reply_to_account_id = r.opt_str();
+    s.reply_to_handle = r.opt_str();
+    s.reply_to_author_id = r.opt_str();
+    if (r.boolean())
+        s.reply_to_author_followed = r.boolean();
     if (r.boolean())
         s.reblog = std::make_shared<Status>(read_status(r, depth + 1));
     if (r.boolean())

--- a/core/src/timeline/client_filter.cpp
+++ b/core/src/timeline/client_filter.cpp
@@ -39,6 +39,12 @@ bool client_filter_should_show(const ClientFilter& f, const TimelineItem& item,
     const bool is_original = !is_boost && !is_reply_to_id;
     const bool is_my_post = !me_id.empty() && author_id == me_id;
     const bool is_my_reply = is_reply_to_id && is_my_post;
+    const bool bluesky_reply_to_me =
+        post.platform == Platform::Bluesky && post.reply_to_author_id.has_value() &&
+        !me_id.empty() && *post.reply_to_author_id == me_id;
+    const bool bluesky_self_reply =
+        post.platform == Platform::Bluesky && post.reply_to_author_id.has_value() &&
+        *post.reply_to_author_id == author_id;
 
     if (is_boost && !f.boosts)
         return false;
@@ -49,6 +55,11 @@ bool client_filter_should_show(const ClientFilter& f, const TimelineItem& item,
     if (is_reply && !f.replies)
         return false;
     if (is_reply_to_me && !f.replies_to_me)
+        return false;
+    if (post.platform == Platform::Bluesky && is_reply && !is_reply_to_me &&
+        !bluesky_reply_to_me && !bluesky_self_reply &&
+        !f.replies_to_unfollowed && post.reply_to_author_followed.has_value() &&
+        !*post.reply_to_author_followed)
         return false;
     if (is_original && !f.original)
         return false;

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,7 @@ FastSMRW changelog
 0.5.3
 -----
 
+- New: optionally hide Bluesky replies to people you do not follow with the timeline's client filters.
 - Fixed: pressing Enter on a follow request offers Accept and Reject again — and now works in every app, including the invisible interface, the Mac, iPhone, Android, and Linux.
 - New: on Linux, pressing Enter on a user list offers the same user actions as Windows — follow, mute or block, and Accept or Reject on the Follow Requests list — and Shift+arrows select several users to act on at once.
 - New: find posts in a timeline is now in every app — Command+F, Command+G and Command+Shift+G on the Mac, and Find in the More menu on iPhone and Android (with iPad keyboard shortcuts) — joining Windows and Linux.

--- a/ios/src/ManagerScreens.swift
+++ b/ios/src/ManagerScreens.swift
@@ -433,6 +433,8 @@ final class ClientFilterViewController: StaticFormViewController {
             ("Original posts", "original", filter.original),
             ("Replies", "replies", filter.replies),
             ("Replies to me", "replies_to_me", filter.repliesToMe),
+            ("Bluesky replies to people you don't follow", "replies_to_unfollowed",
+             filter.repliesToUnfollowed),
             ("Threads (self-replies)", "threads", filter.threads),
             ("Boosts", "boosts", filter.boosts),
             ("Quotes", "quotes", filter.quotes),

--- a/linux/src/main_window.cpp
+++ b/linux/src/main_window.cpp
@@ -2604,6 +2604,7 @@ void MainWindow::ev_client_filter(const json& e) {
     const std::vector<std::pair<std::string, std::string>> kinds = {
         {"original", "_Original posts"},   {"replies", "_Replies"},
         {"replies_to_me", "Replies to _me"}, {"threads", "_Threads"},
+        {"replies_to_unfollowed", "Bluesky replies to people you don't _follow"},
         {"boosts", "_Boosts"},             {"quotes", "_Quotes"},
         {"media", "Posts with me_dia"},    {"no_media", "Posts _without media"},
         {"my_posts", "M_y posts"},         {"my_replies", "My repl_ies"}};

--- a/macos/src/ClientFilterWindowController.swift
+++ b/macos/src/ClientFilterWindowController.swift
@@ -25,6 +25,8 @@ final class ClientFilterWindowController: NSWindowController {
             ("Original posts", "original", filter.original),
             ("Replies", "replies", filter.replies),
             ("Replies to me", "replies_to_me", filter.repliesToMe),
+            ("Bluesky replies to people you don't follow", "replies_to_unfollowed",
+             filter.repliesToUnfollowed),
             ("Threads (self-replies)", "threads", filter.threads),
             ("Boosts", "boosts", filter.boosts),
             ("Quotes", "quotes", filter.quotes),

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -107,6 +107,7 @@ void test_update_installer_asset();
 // From test_filters.cpp
 void test_client_filter_post_types();
 void test_client_filter_media_and_me();
+void test_client_filter_bluesky_unfollowed_replies();
 void test_client_filter_text();
 void test_server_filter_metadata();
 
@@ -212,6 +213,7 @@ int main() {
     test_update_installer_asset();
     test_client_filter_post_types();
     test_client_filter_media_and_me();
+    test_client_filter_bluesky_unfollowed_replies();
     test_client_filter_text();
     test_server_filter_metadata();
     test_refresh_fills_gap_below_streamed_top();

--- a/tests/test_bluesky_map.cpp
+++ b/tests/test_bluesky_map.cpp
@@ -32,6 +32,13 @@ static const char* kFeedItem = R"JSON({
     "$type": "app.bsky.feed.defs#reasonRepost",
     "by": { "did": "did:plc:carol", "handle": "carol.bsky.social", "displayName": "Carol" },
     "indexedAt": "2024-06-28T12:30:00.000Z"
+  },
+  "reply": {
+    "parent": {
+      "author": {
+        "did": "did:plc:other", "handle": "other.bsky.social", "viewer": {}
+      }
+    }
   }
 })JSON";
 
@@ -55,9 +62,25 @@ void test_bluesky_feed_mapping() {
     CHECK(inner.like_uri.has_value());
     CHECK_EQ(inner.like_uri.value(), std::string("at://did:plc:me/app.bsky.feed.like/like1"));
     CHECK(inner.in_reply_to_id.has_value());
+    CHECK(!inner.in_reply_to_account_id.has_value());
+    CHECK_EQ(inner.reply_to_author_id.value(), std::string("did:plc:other"));
+    CHECK_EQ(inner.reply_to_handle.value(), std::string("other.bsky.social"));
+    CHECK(inner.reply_to_author_followed.has_value());
+    CHECK(!*inner.reply_to_author_followed);
     CHECK_EQ(inner.media_attachments.size(), size_t(1));
     CHECK(inner.media_attachments[0].type == MediaAttachment::Kind::Image);
     CHECK_EQ(inner.media_attachments[0].description, std::string("a view"));
+
+    json followed_item = json::parse(kFeedItem);
+    followed_item["reply"]["parent"]["author"]["viewer"]["following"] =
+        "at://did:plc:me/app.bsky.graph.follow/f1";
+    const Status followed = bluesky::map_feed_item(followed_item);
+    CHECK(followed.display_status().reply_to_author_followed.value_or(false));
+
+    json unknown_item = json::parse(kFeedItem);
+    unknown_item["reply"]["parent"]["author"].erase("viewer");
+    const Status unknown = bluesky::map_feed_item(unknown_item);
+    CHECK(!unknown.display_status().reply_to_author_followed.has_value());
 }
 
 void test_bluesky_notification_mapping() {

--- a/tests/test_filters.cpp
+++ b/tests/test_filters.cpp
@@ -109,6 +109,42 @@ void test_client_filter_media_and_me() {
     CHECK(client_filter_should_show(f, to_me, me));
 }
 
+void test_client_filter_bluesky_unfollowed_replies() {
+    const std::string me = "did:plc:me";
+    ClientFilter f;
+    f.replies_to_unfollowed = false;
+
+    TimelineItem reply = make_status("1", "did:plc:author");
+    Status* post = reply.mutable_status();
+    post->platform = Platform::Bluesky;
+    post->in_reply_to_id = "parent";
+    post->reply_to_author_id = "did:plc:stranger";
+    post->reply_to_author_followed = false;
+    CHECK(client_filter_should_show(ClientFilter{}, reply, me)); // default preserves visibility
+    CHECK(!client_filter_should_show(f, reply, me));
+
+    post->reply_to_author_followed = true;
+    CHECK(client_filter_should_show(f, reply, me));
+
+    post->reply_to_author_followed.reset();
+    CHECK(client_filter_should_show(f, reply, me)); // unknown stays visible
+
+    post->reply_to_author_followed = false;
+    post->reply_to_author_id = me;
+    CHECK(client_filter_should_show(f, reply, me)); // new option does not hide replies to me
+
+    post->reply_to_author_id = post->account.id;
+    CHECK(client_filter_should_show(f, reply, me)); // new option does not hide self-replies
+
+    f = ClientFilter{};
+    f.replies_to_unfollowed = false;
+    post->platform = Platform::Mastodon;
+    post->in_reply_to_account_id = "someone";
+    post->reply_to_author_id.reset();
+    post->reply_to_author_followed = false;
+    CHECK(client_filter_should_show(f, reply, me)); // Bluesky only
+}
+
 void test_client_filter_text() {
     const std::string me = "me";
     Status s;

--- a/tests/test_store.cpp
+++ b/tests/test_store.cpp
@@ -41,6 +41,9 @@ void test_timeline_cache() {
         s.id = "a2";
         s.text = "second";
         s.created_at = 200;
+        s.reply_to_handle = "parent.test";
+        s.reply_to_author_id = "did:plc:parent";
+        s.reply_to_author_followed = false;
         items.push_back(TimelineItem{std::move(s)});
     }
 
@@ -50,6 +53,11 @@ void test_timeline_cache() {
     CHECK_EQ(loaded.items[0].id(), std::string("s:a1"));
     CHECK(loaded.items[1].status() != nullptr);
     CHECK_EQ(loaded.items[1].status()->text, std::string("second"));
+    CHECK_EQ(loaded.items[1].status()->reply_to_handle.value(), std::string("parent.test"));
+    CHECK_EQ(loaded.items[1].status()->reply_to_author_id.value(),
+             std::string("did:plc:parent"));
+    CHECK(loaded.items[1].status()->reply_to_author_followed.has_value());
+    CHECK(!*loaded.items[1].status()->reply_to_author_followed);
     CHECK(loaded.scrollback.has_value()); // cursor round-trips
     CHECK_EQ(loaded.scrollback->value, std::string("a2"));
 

--- a/windows/resources/app.rc
+++ b/windows/resources/app.rc
@@ -516,8 +516,9 @@ BEGIN
     AUTOCHECKBOX "Posts with&out media", IDC_CF_NO_MEDIA, 10, 70, 110, 10
     AUTOCHECKBOX "&Your posts", IDC_CF_MY_POSTS, 128, 70, 112, 10
     AUTOCHECKBOX "Your r&eplies", IDC_CF_MY_REPLIES, 10, 82, 110, 10
-    LTEXT        "Contains te&xt (post, name or handle):", -1, 10, 100, 230, 9
-    EDITTEXT     IDC_CF_TEXT, 10, 112, 230, 12, ES_AUTOHSCROLL | WS_TABSTOP
+    AUTOCHECKBOX "Bluesky replies to people you don't &follow", IDC_CF_REPLIES_UNFOLLOWED, 10, 94, 230, 10
+    LTEXT        "Contains te&xt (post, name or handle):", -1, 10, 112, 230, 9
+    EDITTEXT     IDC_CF_TEXT, 10, 124, 230, 12, ES_AUTOHSCROLL | WS_TABSTOP
     DEFPUSHBUTTON "&Apply", IDOK, 70, 176, 52, 14
     PUSHBUTTON   "C&lear", IDC_CF_CLEAR, 126, 176, 52, 14
     PUSHBUTTON   "Cancel", IDCANCEL, 182, 176, 52, 14

--- a/windows/resources/resource.h
+++ b/windows/resources/resource.h
@@ -182,6 +182,7 @@
 #define IDC_CF_MY_REPLIES   460
 #define IDC_CF_TEXT         461
 #define IDC_CF_CLEAR        462
+#define IDC_CF_REPLIES_UNFOLLOWED 463
 
 // Server Filters manager (Mastodon /api/v2/filters).
 #define IDD_SERVER_FILTERS  470

--- a/windows/src/client_filters_dialog.cpp
+++ b/windows/src/client_filters_dialog.cpp
@@ -28,6 +28,7 @@ INT_PTR CALLBACK ClientFilterProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
         set_check(dlg, IDC_CF_ORIGINAL, v->original);
         set_check(dlg, IDC_CF_REPLIES, v->replies);
         set_check(dlg, IDC_CF_REPLIES_ME, v->replies_to_me);
+        set_check(dlg, IDC_CF_REPLIES_UNFOLLOWED, v->replies_to_unfollowed);
         set_check(dlg, IDC_CF_THREADS, v->threads);
         set_check(dlg, IDC_CF_BOOSTS, v->boosts);
         set_check(dlg, IDC_CF_QUOTES, v->quotes);
@@ -45,6 +46,7 @@ INT_PTR CALLBACK ClientFilterProc(HWND dlg, UINT msg, WPARAM wp, LPARAM lp) {
             v->original = get_check(dlg, IDC_CF_ORIGINAL);
             v->replies = get_check(dlg, IDC_CF_REPLIES);
             v->replies_to_me = get_check(dlg, IDC_CF_REPLIES_ME);
+            v->replies_to_unfollowed = get_check(dlg, IDC_CF_REPLIES_UNFOLLOWED);
             v->threads = get_check(dlg, IDC_CF_THREADS);
             v->boosts = get_check(dlg, IDC_CF_BOOSTS);
             v->quotes = get_check(dlg, IDC_CF_QUOTES);

--- a/windows/src/client_filters_dialog.hpp
+++ b/windows/src/client_filters_dialog.hpp
@@ -12,6 +12,7 @@ struct ClientFilterValues {
     bool original = true;
     bool replies = true;
     bool replies_to_me = true;
+    bool replies_to_unfollowed = true;
     bool threads = true;
     bool boosts = true;
     bool quotes = true;

--- a/windows/src/main_window.cpp
+++ b/windows/src/main_window.cpp
@@ -2685,6 +2685,7 @@ void MainWindow::ev_client_filter(const json& e) {
     v.original = f.value("original", true);
     v.replies = f.value("replies", true);
     v.replies_to_me = f.value("replies_to_me", true);
+    v.replies_to_unfollowed = f.value("replies_to_unfollowed", true);
     v.threads = f.value("threads", true);
     v.boosts = f.value("boosts", true);
     v.quotes = f.value("quotes", true);
@@ -2697,6 +2698,7 @@ void MainWindow::ev_client_filter(const json& e) {
     case ClientFilterAction::Apply: {
         json nf = {{"original", v.original},         {"replies", v.replies},
                    {"replies_to_me", v.replies_to_me}, {"threads", v.threads},
+                   {"replies_to_unfollowed", v.replies_to_unfollowed},
                    {"boosts", v.boosts},             {"quotes", v.quotes},
                    {"media", v.media},               {"no_media", v.no_media},
                    {"my_posts", v.my_posts},         {"my_replies", v.my_replies},


### PR DESCRIPTION
## Summary

- add an opt-in client filter for hiding Bluesky replies whose parent author is not followed
- preserve existing behavior by default and keep replies to the authenticated user, self-replies, followed-parent replies, and replies with unknown relationship data visible
- capture parent DID and viewer follow state from the embedded Bluesky feed response without additional network requests
- persist the new option and reply-parent metadata, and expose it in the existing Windows, macOS, iOS, and Linux client-filter interfaces

## Testing

- On linux, bash linux/build-core.sh test
- 518 checks, 0 failures
The ALSA/JACK diagnostics during the test run were expected because the test environment had no audio device.
- On windows, ./run.bat test
- 518 checks, 0 failures
- I ran the build on my windows machine and the new filter works as expected.