### PR TITLE
Fix Android bottom tab bar hiding under the navigation bar

### DIFF
--- a/android/app/src/main/java/me/masonasons/fastsm/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/me/masonasons/fastsm/ui/home/HomeScreen.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -228,7 +231,15 @@ fun HomeScreen(
                 if (!tabsAtBottom) tabBar()
             }
         },
-        bottomBar = { if (tabsAtBottom) tabBar() },
+        bottomBar = {
+            // TopAppBar applies status-bar insets on its own, but this plain Row
+            // doesn't — without navigationBars padding here, the bottom-docked
+            // tab strip renders under the gesture/button nav bar and becomes
+            // untouchable and unreachable to TalkBack.
+            if (tabsAtBottom) {
+                Box(Modifier.windowInsetsPadding(WindowInsets.navigationBars)) { tabBar() }
+            }
+        },
         floatingActionButton = {
             FloatingActionButton(onClick = viewModel::composeNew) {
                 Icon(Icons.Filled.Edit, contentDescription = "New post")

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,6 +5,7 @@ FastSMRW changelog
 -----
 
 - Fixed: pressing Enter on a follow request offers Accept and Reject again — and now works in every app, including the invisible interface, the Mac, iPhone, Android, and Linux.
+- Fixed: on Android, the timeline tab bar no longer hides behind the on-screen navigation bar when set to the bottom of the screen, so the tabs are always visible and reachable by touch and TalkBack.
 - New: on Linux, pressing Enter on a user list offers the same user actions as Windows — follow, mute or block, and Accept or Reject on the Follow Requests list — and Shift+arrows select several users to act on at once.
 - New: find posts in a timeline is now in every app — Command+F, Command+G and Command+Shift+G on the Mac, and Find in the More menu on iPhone and Android (with iPad keyboard shortcuts) — joining Windows and Linux.
 - New: on the Mac, view your muted users, blocked users, and pending follow requests from the Account menu.


### PR DESCRIPTION
The custom tab strip lacked navigationBars inset padding, so when set to the bottom of the screen it could render underneath the system gesture/button nav bar, making tabs untouchable and unreachable by TalkBack.