### PR TITLE
Fix the dead attachment button in the Mac post composer

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -8,6 +8,7 @@ FastSMRW changelog
 - New: on Android, get notified of mentions, boosts, favorites, follows and more while the app is closed — turn on Push notifications in Settings (Mastodon).
 - New: open a timeline for a hashtag in a post — the new "Open Hashtag Timeline" action lists the post's hashtags and opens the one you pick.
 - New: on iPhone with VoiceOver, a three-finger swipe left or right on the timeline moves to the next or previous timeline.
+- Fixed: on the Mac, the "Add…" button in the new post window now opens the file chooser so you can attach photos, videos and audio again.
 - Fixed: on Android, FastSMRW now runs on newer phones that use a larger memory page size, which could refuse to load it.
 
 0.5.6

--- a/macos/FastSMRW.entitlements
+++ b/macos/FastSMRW.entitlements
@@ -6,5 +6,10 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<!-- Lets the sandboxed app read files the user picks in an Open panel (post
+	     attachments). Without it the system refuses to show the panel at all, so
+	     the compose window's "Add…" button silently does nothing. -->
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add `com.apple.security.files.user-selected.read-only` to the Mac app's entitlements, so the sandboxed app can show an Open panel and read what the user picks.
- Add the user-facing changelog entry under 0.5.7.

No code changes: `ComposeWindowController.addAttachment()` was already correct.

## Root cause

The Mac app is sandboxed (`macos/FastSMRW.entitlements`) but only ever declared `app-sandbox` and `network.client`. Without the user-selected file entitlement the system refuses to show the Open panel at all, so pressing "Add…" in the compose window ran `addAttachment()`, asked for a panel, and got nothing — the button appeared dead, with no error shown to the user and nothing logged to explain it.

## Validation

Confirmed with a minimal AppKit app ad-hoc-signed with this app's exact entitlements, calling `NSOpenPanel.begin` and reporting `isVisible` afterwards:

- sandbox + network only → `panel visible=false windows=0`
- same app with `files.user-selected.read-only` added → `panel visible=true windows=1`

The other candidate cause was ruled out the same way: the composer is presented as a sheet, so a second test attached an `NSOpenPanel` to a window that was itself a sheet, sandboxed → `visible=true attached=true`. Sheet-on-sheet is fine, which is why no compose code changed.

Also:

- macOS Debug build via `macos/build.sh` — **BUILD SUCCEEDED**
- `codesign -d --entitlements -` on the built app confirms `files.user-selected.read-only` is in the signed binary
- `plutil -lint` on the entitlements file
- `git diff --check`

Read-only is sufficient: the panel returns a sandbox extension for each file it hands back, which is enough to read an attachment, and nothing in the app writes to a user-chosen location.

Not yet verified live: picking a real file through the composer and watching it upload needs a real account and a screen reader.

## Scope

Mac-only. Windows uses the common file dialog, iOS a `PHPickerViewController` (`ios/src/ComposeViewController.swift`), and Android an `OpenDocument` picker (`ComposeScreen.kt`) — none are gated by this entitlement, so there is no parity work to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Av8UFrTE6bopDrGKgjN9zb
